### PR TITLE
If already a end distance is found, only ways which are shorter are calculated

### DIFF
--- a/shortestPath.js
+++ b/shortestPath.js
@@ -34,21 +34,26 @@ const findShortestPath = (graph, startNode, endNode) => {
 		// find its distance from the start node & its child nodes
 		let distance = distances[node];
 		let children = graph[node];
-		// for each of those child nodes
-		for (let child in children) {
-			// make sure each child node is not the start node
-			if (String(child) === String(startNode)) {
-				continue;
-			} else {
-				// save the distance from the start node to the child node
-				let newdistance = distance + children[child];
-				// if there's no recorded distance from the start node to the child node in the distances object
-				// or if the recorded distance is shorter than the previously stored distance from the start node to the child node
-				// save the distance to the object
-				// record the path
-				if (!distances[child] || distances[child] > newdistance) {
-					distances[child] = newdistance;
-					parents[child] = node;
+
+		// if already a end distance is found, we allow only ways which are shorter
+		if (!distances[endNode] || distances[endNode] > distance) {
+			// for each of those child nodes
+			for (let child in children) {
+				// make sure each child node is not the start node
+				if (String(child) === String(startNode)) {
+					continue;
+				} else {
+					// save the distance from the start node to the child node
+					let newdistance = distance + children[child];
+					// if there's no recorded distance from the start node to the child node in the distances object
+					// or if the recorded distance is shorter than the previously stored distance from the start node to the child node
+					// save the distance to the object but if already a end distance is found, it must be shorter then it
+					// record the path
+					if ((!distances[child] || distances[child] > newdistance)
+						&& (!distances[endNode] || distances[endNode] > newdistance)) {
+						distances[child] = newdistance;
+						parents[child] = node;
+					}
 				}
 			}
 		}

--- a/shortestPathWithLogs.js
+++ b/shortestPathWithLogs.js
@@ -34,29 +34,34 @@ const findShortestPathWithLogs = (graph, startNode, endNode) => {
 		// find its distance from the start node & its child nodes
 		let distance = distances[node];
 		let children = graph[node];
-		// for each of those child nodes
-		for (let child in children) {
-			// make sure each child node is not the start node
-			if (String(child) === String(startNode)) {
-				console.log("don't return to the start node! 🙅");
-				continue;
-			} else {
-				console.log("startNode: " + startNode);
-				console.log("distance from node " + parents[node] + " to node " + node + ")");
-				console.log("previous distance: " + distances[node]);
-				// save the distance from the start node to the child node
-				let newdistance = distance + children[child];
-				console.log("new distance: " + newdistance);
-				// if there's no recorded distance from the start node to the child node in the distances object
-				// or if the recorded distance is shorter than the previously stored distance from the start node to the child node
-				// save the distance to the object
-				// record the path
-				if (!distances[child] || distances[child] > newdistance) {
-					distances[child] = newdistance;
-					parents[child] = node;
-					console.log("distance + parents updated");
+
+		// if already a end distance is found, we allow only ways which are shorter
+		if (!distances[endNode] || distances[endNode] > distance) {
+			// for each of those child nodes
+			for (let child in children) {
+				// make sure each child node is not the start node
+				if (String(child) === String(startNode)) {
+					console.log("don't return to the start node! 🙅");
+					continue;
 				} else {
-					console.log("not updating, because a shorter path already exists!");
+					console.log("startNode: " + startNode);
+					console.log("distance from node " + parents[node] + " to node " + node + ")");
+					console.log("previous distance: " + distances[node]);
+					// save the distance from the start node to the child node
+					let newdistance = distance + children[child];
+					console.log("new distance: " + newdistance);
+					// if there's no recorded distance from the start node to the child node in the distances object
+					// or if the recorded distance is shorter than the previously stored distance from the start node to the child node
+					// save the distance to the object but if already a end distance is found, it must be shorter then it
+					// record the path
+					if ((!distances[child] || distances[child] > newdistance)
+						&& (!distances[endNode] || distances[endNode] > newdistance)) {
+						distances[child] = newdistance;
+						parents[child] = node;
+						console.log("distance + parents updated");
+					} else {
+						console.log("not updating, because a shorter path already exists!");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Thank you for your sharing Dijkstra's Algorithm in JavaScript!

I have found a small optimization with a big impact, but I don't know if it is compatible with the "thinking" / "logic" behind Dijkstra's Algorithm.

If already a end distance is found, it don't goes anymore over the node which are farer away then the distance to the end node. This makes it much fast if there are many nodes in the graph.

Current code:
![shortest-path-slow](https://user-images.githubusercontent.com/19800037/187088737-e42aba27-9312-4643-863c-0dd94b9f8cf6.gif)

With optimization :
![shortest-path-fast](https://user-images.githubusercontent.com/19800037/187088733-d9200f57-51be-4f92-9b9d-e05857968fc7.gif)

